### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/groupreg.php
+++ b/groupreg.php
@@ -527,7 +527,7 @@ function groupreg_civicrm_buildForm($formName, &$form) {
 }
 
 function _groupreg_add_bhfe(array $elementNames, CRM_Core_Form &$form) {
-  $bhfe = $form->get_template_vars('beginHookFormElements');
+  $bhfe = $form->getTemplateVars('beginHookFormElements');
   if (!$bhfe) {
     $bhfe = [];
   }


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.