### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/GroupregPrefill/Get.php
+++ b/api/v3/GroupregPrefill/Get.php
@@ -23,7 +23,7 @@ function _civicrm_api3_groupreg_prefill_Get_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_prefill_Get($params) {
   unset($params['return']);

--- a/api/v3/GroupregPrefill/Get.php
+++ b/api/v3/GroupregPrefill/Get.php
@@ -22,8 +22,6 @@ function _civicrm_api3_groupreg_prefill_Get_spec(&$spec) {
  *   API result descriptor
  *
  * @see civicrm_api3_create_success
- *
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_prefill_Get($params) {
   unset($params['return']);

--- a/api/v3/GroupregPriceField.php
+++ b/api/v3/GroupregPriceField.php
@@ -21,7 +21,7 @@ function _civicrm_api3_groupreg_price_field_create_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'GroupregPriceField');
@@ -35,7 +35,7 @@ function civicrm_api3_groupreg_price_field_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -49,7 +49,7 @@ function civicrm_api3_groupreg_price_field_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'GroupregPriceField');

--- a/api/v3/GroupregPriceField.php
+++ b/api/v3/GroupregPriceField.php
@@ -20,8 +20,6 @@ function _civicrm_api3_groupreg_price_field_create_spec(&$spec) {
  *
  * @return array
  *   API result descriptor
- *
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'GroupregPriceField');
@@ -34,8 +32,6 @@ function civicrm_api3_groupreg_price_field_create($params) {
  *
  * @return array
  *   API result descriptor
- *
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -48,8 +44,6 @@ function civicrm_api3_groupreg_price_field_delete($params) {
  *
  * @return array
  *   API result descriptor
- *
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_groupreg_price_field_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, 'GroupregPriceField');


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.